### PR TITLE
Checked for placing ships before starting the game

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -73,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
     startMultiPlayer()
   }
 
+
   // Multiplayer
   function startMultiPlayer() {
     const socket = io();
@@ -126,6 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Ready button click
     startButton.addEventListener('click', () => {
+      
       if(allShipsPlaced) playGameMulti(socket)
       else infoDisplay.innerHTML = "Please place all ships"
     })
@@ -170,7 +172,7 @@ document.addEventListener('DOMContentLoaded', () => {
     generate(shipArray[4])
 
     startButton.addEventListener('click', () => {
-      setupButtons.style.display = 'none'
+     
       playGameSingle()
     })
   }
@@ -335,12 +337,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Game Logic for Single Player
   function playGameSingle() {
-    if (isGameOver) return
+    if (isGameOver) return;
+      // Check if ships are placed
+  if (!allShipsPlaced) {
+    turnDisplay.innerHTML = 'Place all your ships first!';
+    return; // Exit the function if ships are not placed
+  }
+   setupButtons.style.display = 'none'
     if (currentPlayer === 'user') {
       turnDisplay.innerHTML = 'Your Go'
       computerSquares.forEach(square => square.addEventListener('click', function(e) {
         shotFired = square.dataset.id
         revealSquare(square.classList)
+        
       }))
     }
     if (currentPlayer === 'enemy') {


### PR DESCRIPTION
This PR addresses issue #1: "Game Can Be Played Without Adding Ships to the Board" by implementing a check to ensure all ships are placed on the board before the game can start. It prevents the user from starting the game until the ships are properly positioned, improving the game's flow and preventing unintended gameplay behavior.

**Changes Made:**
**Ship Placement Check:**
Added a validation step before the game starts, ensuring that the user cannot begin until all ships have been placed on the board. This check is incorporated in both the single-player and multiplayer modes.

**UI Feedback:**
Updated the game start button (start button) to remain disabled until the ships are correctly placed, and added a prompt in the info display to guide the user to place ships first.

**Play Logic Update:**
Modified the playGameSingle() function to check for ship placement and prevent the game logic from proceeding until the player completes this step.

**Testing:**
Verified the changes by manually testing the flow of ship placement and ensuring that the game starts only after all ships are on the board.

![image](https://github.com/user-attachments/assets/9beb498d-4ba7-4313-ac11-6efc5d825e7d)
It won't allow the user to start the game before placing the ships and displaying the message

![image](https://github.com/user-attachments/assets/6b84670b-0346-4a8e-a4ba-99d9b380d666)
It works as normal and  starts the game when the ships are placed onto the board.